### PR TITLE
Task 7 FE (Lambda Authorizer + Cognito Authorization)

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -32,11 +32,15 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
 
   const uploadFile = async (e: any) => {
       // Get the presigned URL
+      const token = localStorage.getItem('authorization_token');
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
+        },
+        headers: {
+          Authorization: token ? `Basic ${token}` : undefined
         }
       })
       console.log('File to upload: ', file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,19 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error?.response?.status === 400) {
-      alert(error.response.data?.data);
+    switch (error?.response?.status) {
+      case 400: {
+        alert(error.response.data?.data);
+        break;
+      }
+      case 401: {
+        alert("Unauthorized");
+        break;
+      }
+      case 403: {
+        alert("Forbidden");
+        break;
+      }
     }
 
     return Promise.reject(error?.response ?? error);


### PR DESCRIPTION
## CloudFront: https://d38mkylof58shi.cloudfront.net/

5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

Additional task:
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file